### PR TITLE
Custom client certificates and keys for CertFP

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,12 @@ type config struct {
 	// Path to SSL cert (if any).
 	Cert string `json:"cert"`
 
+	// Path to SSL client certificate (if any).
+	ClientCert string `json:"client_cert"`
+
+	// Path to SSL client key (if any).
+	ClientKey string `json:"client_key"`
+
 	// List of channels to connect to.
 	Chan []string `json:"channels"`
 }

--- a/main.go
+++ b/main.go
@@ -113,8 +113,16 @@ func connect(config config) (conn net.Conn, err error) {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(certFile)
 
-		config := &tls.Config{RootCAs: caCertPool}
-		return tls.Dial(netw, addr, config)
+		tlsConfig := &tls.Config{RootCAs: caCertPool}
+		if len(config.ClientCert) >= 1 && len(config.ClientKey) >= 1 {
+			clientCert, err := tls.LoadX509KeyPair(config.ClientCert, config.ClientKey)
+			if err != nil {
+				return nil, err
+			}
+
+			tlsConfig.Certificates = []tls.Certificate{ clientCert }
+		}
+		return tls.Dial(netw, addr, tlsConfig)
 	}
 
 	return net.Dial(netw, addr)


### PR DESCRIPTION
Add support for TLS client certificates and keys to allow authentication with CertFP
