### PR TITLE
replace min with m in time-duration string to enhance user experience

### DIFF
--- a/modules/remind/remind.go
+++ b/modules/remind/remind.go
@@ -50,6 +50,7 @@ func (m *Module) Load(client *irc.Client) error {
 			return nil
 		}
 
+		splited[1] = strings.Replace(splited[1],"min","m",1)
 		duration, err := time.ParseDuration(splited[1])
 		if err != nil {
 			return c.Write("NOTICE %s :ERROR: %s", msg.Receiver, err.Error())


### PR DESCRIPTION
Most users try to use the reminder module like this:
!remind 3min45s
which results in an error since the time.parseduration() can't handle 'min'(it expects 'm' for minutes).
This happens so often that it would improve the user experience if it is also possible to use 'min' in the remind module.